### PR TITLE
Add randomness to sugarcane farm

### DIFF
--- a/sc_farming.py
+++ b/sc_farming.py
@@ -24,7 +24,7 @@ def random_order_funcs(funcs: list['func']):
     random.shuffle(funcs)
     for func in funcs:
         func(coeff)
-        coeff *= 5
+        coeff *= 3
 
 def start_left(coeff = 1):
     random_stop(coeff)

--- a/sc_farming.py
+++ b/sc_farming.py
@@ -18,44 +18,39 @@ offset2 = random.randint(1, 8) / 10
 
 
 def stop_left():
-    if (random.randint(1, 5) == 1):
-        time.sleep(random.randint(1, 4) / 10)
-    elif (random.randint(1, 100) == 1):
-        time.sleep(random.randint(50, 150) / 10)
-    else:
-        time.sleep(random.randint(1, 5) / 50)
+    if (random.randint(1, 7) <= 3):
+        time.sleep(random.randint(1, 6) / 10)
+    elif (random.randint(1, 50) == 1):
+        time.sleep(random.randint(100, 150) / 10)
     minescript.player_press_left(False)
 
 def start_back():
-    if (random.randint(1, 5) == 1):
-        time.sleep(random.randint(1, 5) / 10)
-    elif (random.randint(1, 100) == 1):
-        time.sleep(random.randint(50, 150) / 10)
-    else:
-        time.sleep(random.randint(1, 3) / 50)
+    if (random.randint(1, 7) <= 3):
+        time.sleep(random.randint(1, 6) / 10)
+    elif (random.randint(1, 50) == 1):
+        time.sleep(random.randint(50, 120) / 10)
     minescript.player_press_backward(True)
 
 def start_left():
-    if (random.randint(1, 5) == 1):
-        time.sleep(random.randint(1, 4) / 10)
-    elif (random.randint(1, 100) == 1):
-        time.sleep(random.randint(50, 150) / 10)
-    else:
-        time.sleep(random.randint(1, 5) / 50)
+    if (random.randint(1, 7) <= 3):
+        time.sleep(random.randint(1, 6) / 10)
+    elif (random.randint(1, 50) == 1):
+        time.sleep(random.randint(50, 120) / 10)
     minescript.player_press_left(True)
 
 def stop_back():
-    if (random.randint(1, 5) == 1):
-        time.sleep(random.randint(1, 5) / 10)
-    elif (random.randint(1, 100) == 1):
-        time.sleep(random.randint(50, 150) / 10)
-    else:
-        time.sleep(random.randint(1, 3) / 50)
+    if (random.randint(1, 7) <= 3):
+        time.sleep(random.randint(1, 6) / 10)
+    elif (random.randint(1, 50) == 1):
+        time.sleep(random.randint(50, 120) / 10)
     minescript.player_press_backward(False)
+
+def stop_attack():
+    minescript.player_press_attack(False)
 
 def should_continue():
     return ((minescript.player_position()[0] < (FARM_START_POSITION[0] + 90 - FARMING_X_OFFSET))
-    or (minescript.player_position()[2] < (FARM_START_POSITION[2] + 90 - FARMING_Z_OFFSET)))
+    or (minescript.player_position()[2] < (FARM_START_POSITION[2] + 91 - FARMING_Z_OFFSET)))
 
 while True:
     lane_start_position = minescript.player_position()
@@ -70,7 +65,7 @@ while True:
 
 
     while should_continue():
-        while should_continue() and (minescript.player_position()[0] < 3 + lane_start_position[0] - random.randint(3, 8) / 10):
+        while should_continue() and (minescript.player_position()[0] < (3 + lane_start_position[0] - random.randint(3, 8) / 10)):
             time.sleep(0.001)
         if not should_continue():
             break
@@ -85,7 +80,8 @@ while True:
         lane_start_position = minescript.player_position()
 
 
-        while minescript.player_position()[0] < 3 + lane_start_position[0] - random.randint(3, 8) / 10:
+
+        while should_continue() and (minescript.player_position()[0] < (3 + lane_start_position[0] - random.randint(3, 8) / 10)):
             time.sleep(0.001)
         if not should_continue():
             break
@@ -99,13 +95,10 @@ while True:
 
         lane_start_position = minescript.player_position()
 
-
-    minescript.player_press_left(False)
-    time.sleep(random.randint(3, 8) / 50)
-    minescript.player_press_backward(False)
-
-    time.sleep(random.randint(3, 8) / 10)
-    minescript.player_press_attack(False)
+    stop_funcs = [stop_left, stop_back, stop_attack]
+    random.shuffle(stop_funcs)
+    for func in stop_funcs:
+        func()
 
     minescript.execute('warp garden')
     time.sleep(random.randint(2, 8) / 10)

--- a/sc_farming.py
+++ b/sc_farming.py
@@ -7,98 +7,76 @@ import sys
 lane_start_position = minescript.player_position()
 FARM_START_POSITION = minescript.player_position()
 
-
-
 FARMING_X_OFFSET = random.randint(1, 15) / 10
 FARMING_Z_OFFSET = random.randint(1, 15) / 10
 
 offset1 = random.randint(1, 8) / 10
 offset2 = random.randint(1, 8) / 10
 
-
-
-def stop_left():
-    if (random.randint(1, 7) <= 3):
+def random_stop(coeff = 1):
+    if (random.randint(1, 7 * coeff) <= 3):
         time.sleep(random.randint(1, 6) / 10)
-    elif (random.randint(1, 50) == 1):
+    elif (random.randint(1, 50 * coeff) == 1):
         time.sleep(random.randint(100, 150) / 10)
-    minescript.player_press_left(False)
 
-def start_back():
-    if (random.randint(1, 7) <= 3):
-        time.sleep(random.randint(1, 6) / 10)
-    elif (random.randint(1, 50) == 1):
-        time.sleep(random.randint(50, 120) / 10)
-    minescript.player_press_backward(True)
+def random_order_funcs(funcs: list['func']):
+    coeff = 1
+    random.shuffle(funcs)
+    for func in funcs:
+        func(coeff)
+        coeff *= 5
 
-def start_left():
-    if (random.randint(1, 7) <= 3):
-        time.sleep(random.randint(1, 6) / 10)
-    elif (random.randint(1, 50) == 1):
-        time.sleep(random.randint(50, 120) / 10)
+def start_left(coeff = 1):
+    random_stop(coeff)
     minescript.player_press_left(True)
 
-def stop_back():
-    if (random.randint(1, 7) <= 3):
-        time.sleep(random.randint(1, 6) / 10)
-    elif (random.randint(1, 50) == 1):
-        time.sleep(random.randint(50, 120) / 10)
+def stop_left(coeff = 1):
+    random_stop(coeff)
+    minescript.player_press_left(False)
+
+def start_back(coeff = 1):
+    random_stop(coeff)
+    minescript.player_press_backward(True)
+
+def stop_back(coeff = 1):
+    random_stop(coeff)
     minescript.player_press_backward(False)
 
-def stop_attack():
+def start_attack(coeff = 1):
+    random_stop(coeff)
+    minescript.player_press_attack(True)
+
+def stop_attack(_coeff = 1):
     minescript.player_press_attack(False)
 
 def should_continue():
-    return ((minescript.player_position()[0] < (FARM_START_POSITION[0] + 90 - FARMING_X_OFFSET))
+    return ((minescript.player_position()[0] < (FARM_START_POSITION[0] + 186 - FARMING_X_OFFSET))
     or (minescript.player_position()[2] < (FARM_START_POSITION[2] + 91 - FARMING_Z_OFFSET)))
 
 while True:
     lane_start_position = minescript.player_position()
-    if(random.randint(1, 5) == 1):
-        minescript.player_press_attack(True)
-        time.sleep(random.randint(1, 5) / 50)
-        minescript.player_press_left(True)
-    else:
-        minescript.player_press_left(True)
-        time.sleep(random.randint(1, 5) / 50)
-        minescript.player_press_attack(True)
-
+    random_order_funcs([start_attack, start_left])
 
     while should_continue():
         while should_continue() and (minescript.player_position()[0] < (3 + lane_start_position[0] - random.randint(3, 8) / 10)):
+            random_stop(10000)
             time.sleep(0.001)
         if not should_continue():
             break
 
-        if (random.randint(1, 3) == 1):
-            stop_left()
-            start_back()
-        else:
-            start_back()
-            stop_left()
+        random_order_funcs([stop_left, start_back])
 
         lane_start_position = minescript.player_position()
-
-
-
         while should_continue() and (minescript.player_position()[0] < (3 + lane_start_position[0] - random.randint(3, 8) / 10)):
+            random_stop(10000)
             time.sleep(0.001)
         if not should_continue():
             break
 
-        if (random.randint(1, 3) == 1):
-            start_left()
-            stop_back()
-        else:
-            stop_back()
-            start_left()
-
+        random_order_funcs([start_left, stop_back])
         lane_start_position = minescript.player_position()
 
-    stop_funcs = [stop_left, stop_back, stop_attack]
-    random.shuffle(stop_funcs)
-    for func in stop_funcs:
-        func()
+    random_order_funcs([stop_left, stop_back, stop_attack])
 
     minescript.execute('warp garden')
     time.sleep(random.randint(2, 8) / 10)


### PR DESCRIPTION
## Context
- Previously, this macro was tested on the smaller moonflower farm. The hardcoded farm dimensions now account for two plots (just sc for us in this case)
- There wasn't any random chances of stopping in the middle of farm, and the "random" elements were generally just very limited
- Handles [this issue](https://github.com/training4usaco/SkyblockQOL/issues/2)

## Changes
- Reorged code a lot into functions, mainly created `random_order_funcs` and consolidated a lot of previous messy code into this function
- Created `random_stop` since it's used so much throughout, it also takes a coeff so you can scale the chances which is useful depending on when you want to do the `random_stop`
    - For example, random stopping in the middle of the farm is 10,000 times less likely (because of tick stuff)
    - If you have multiple functions running in sequence (i.e. `stop_back`, `start_left`, etc.), you can make the stop time less and less likely the more functions you have because it would make sense that once you get one input in the rest should follow pretty quickly, so there's less of a chance of the stop happening

## FLUPs
- Add args so you can input the farm type (that way we can hard code in some farm dimensions, eventually would be nice to infer somehow but lwk might be too much work)
- Anti macro check checkers would be nice