### PR TITLE
Add a set home script

### DIFF
--- a/sc_farming.py
+++ b/sc_farming.py
@@ -1,11 +1,18 @@
+import os
 import time
 import random
 
 from system.lib import minescript
-import sys
+import json
+
 
 lane_start_position = minescript.player_position()
-FARM_START_POSITION = minescript.player_position()
+if os.path.exists("home_pos.json"):
+    with open("home_pos.json", "r") as f:
+        FARM_START_POSITION = json.load(f)
+else:
+    FARM_START_POSITION = minescript.player_position()
+minescript.echo(f"Loaded home location: {FARM_START_POSITION}")
 
 FARMING_X_OFFSET = random.randint(1, 15) / 10
 FARMING_Z_OFFSET = random.randint(1, 15) / 10
@@ -50,8 +57,8 @@ def stop_attack(_coeff = 1):
     minescript.player_press_attack(False)
 
 def should_continue():
-    return ((minescript.player_position()[0] < (FARM_START_POSITION[0] + 186 - FARMING_X_OFFSET))
-    or (minescript.player_position()[2] < (FARM_START_POSITION[2] + 91 - FARMING_Z_OFFSET)))
+    return ((minescript.player_position()[0] < (FARM_START_POSITION[0] + 89 - FARMING_X_OFFSET))
+    or (minescript.player_position()[2] < (FARM_START_POSITION[2] + 186 - FARMING_Z_OFFSET)))
 
 while True:
     lane_start_position = minescript.player_position()

--- a/set_home.py
+++ b/set_home.py
@@ -1,0 +1,7 @@
+from system.lib import minescript
+import json
+
+pos = minescript.player_position()
+with open("home_pos.json", "w") as f:
+    json.dump(pos, f)
+minescript.echo(f"Saved to file home location: {pos}")


### PR DESCRIPTION
## Changes
- Added script that sets the "home" location (AKA the farm starting position) and saves it to a file called `home_pos.json`.
- Changed `sc_farming` to load in a home location from a saved file (if the file doesn't exist, it'll just set the home location to the player's current location. Note: this does NOT save the start location locally).
- This is nice because if you stop in the middle of the farm, as long as you run in the right initial direction, the macro will correctly realize when you have reached the end of the farm.
- This will also be useful for keeping track of whether or not the player is in a "lane" for the anti-macro check checker to notify the user when/if the user is tped out of lane

## FLUPs
- Adapt this to other macros as well
- Add warnings for anti-macro checks