### PR TITLE
Add anti-macro check checkers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 venv/
 .env
 .DS_Store
+macro_info.json

--- a/init.py
+++ b/init.py
@@ -1,0 +1,32 @@
+import os
+import threading
+import time
+
+from system.lib import minescript
+import sys
+import json
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+macro_info_file_path = os.path.join(script_dir, "macro_info.json")
+
+farm_dimensions = {
+    'mf': (90, 186),
+    'default': (90, 186)
+}
+
+if __name__ == "__main__":
+    pos = minescript.player_position()
+    orientation = minescript.player_orientation()
+    farm_type = sys.argv[1] if (len(sys.argv) > 1 and sys.argv[1] in farm_dimensions) else 'default'
+    with open(macro_info_file_path, "w") as f:
+        data = {
+            "farm_start": pos,
+            "orientation": orientation,
+            "farm_width": farm_dimensions[farm_type][0],
+            "farm_length": farm_dimensions[farm_type][1],
+        }
+        json.dump(data, f, indent=4)
+    minescript.echo(f"Saved home location: {pos}")
+    macro_thread = threading.Thread(target=minescript.execute('\macro_checker'))
+    macro_thread.start()
+    macro_thread.join()

--- a/macro_checker.py
+++ b/macro_checker.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import time
+import random
+
+import init
+from system.lib import minescript
+import json
+
+def macro_check_alert():
+    script = 'activate application "Prism Launcher"'
+    os.system(f"osascript -e '{script}'")
+    minescript.echo("MACRO CHECK ALERT!!!!!!!!!")
+    time.sleep(random.randint(15, 25) / 10)
+    minescript.execute("\stop")
+    sys.exit(0)
+
+def near_position(position1, position2):
+    return abs(position1[0] - position2[0]) + abs(position1[1] - position2[1]) + abs(position1[2] - position2[2]) < 5
+
+def start_macro_checker():
+    if os.path.exists(init.macro_info_file_path):
+        with open(init.macro_info_file_path, "r") as f:
+            data = json.load(f)
+            farm_start_pos = data["farm_start"]
+            orientation = data["orientation"]
+
+    if farm_start_pos is None or orientation is None:
+        minescript.echo("Remember to run \init! This script won't do anything until you do :)")
+    else:
+        farm_end_pos = (farm_start_pos[0] + data["farm_width"], farm_start_pos[1], farm_start_pos[2] + data["farm_length"])
+
+        prev_position = minescript.player_position()
+        while(True):
+            time.sleep(1)
+            current_position = minescript.player_position()
+            current_orientation = minescript.player_orientation()
+
+            if abs(current_orientation[0] - orientation[0]) > 0.1 or abs(current_orientation[1] - orientation[1]) > 0.1:
+                minescript.echo('camera changed orientation')
+                macro_check_alert()
+
+            if abs(current_position[0] - prev_position[0]) < 0.01 and abs(current_position[2] - prev_position[2]) < 0.01:
+                with open(init.macro_info_file_path, "r") as f:
+                    data = json.load(f)
+                    if "pause_time" not in data or data["pause_time"] == 0.0:
+                        minescript.echo('stayed in place for too long')
+                        macro_check_alert()
+                    else:
+                        time.sleep(data["pause_time"] - 1)
+
+            if(not (near_position(prev_position, farm_end_pos) and near_position(current_position, farm_start_pos)) and
+                    (abs(current_position[0] - prev_position[0]) > 20 or abs(current_position[1] - prev_position[1]) > 20 or abs(current_position[2] - prev_position[2]) > 20)):
+                minescript.echo("teleported a large distance (that wasn't warping to start of farm)")
+                macro_check_alert()
+
+            # This doesn't really work for wart...
+            if (abs(current_position[1] - farm_start_pos[1]) > 1 or
+                    not(min(farm_start_pos[0], farm_end_pos[0]) <= current_position[0] <= max(farm_start_pos[0], farm_end_pos[0])) or
+                    not(min(farm_start_pos[2], farm_end_pos[2]) <= current_position[2] <= max(farm_start_pos[0], farm_end_pos[2]))):
+                minescript.echo('moved outside the farm')
+                macro_check_alert()
+
+            prev_position = current_position
+
+minescript.echo("waiting for macro to start")
+while(True):
+    with open(init.macro_info_file_path, "r") as f:
+        data = json.load(f)
+        if 'active' in data and data['active']:
+            break
+    time.sleep(10)
+
+
+minescript.echo("started macro checking. you're in good hands :)")
+start_macro_checker()
+

--- a/macro_checker.py
+++ b/macro_checker.py
@@ -11,7 +11,7 @@ def macro_check_alert():
     script = 'activate application "Prism Launcher"'
     os.system(f"osascript -e '{script}'")
     minescript.echo("MACRO CHECK ALERT!!!!!!!!!")
-    time.sleep(random.randint(15, 25) / 10)
+    time.sleep(random.randint(5, 15) / 10)
     minescript.execute("\stop")
     sys.exit(0)
 

--- a/set_home.py
+++ b/set_home.py
@@ -1,7 +1,0 @@
-from system.lib import minescript
-import json
-
-pos = minescript.player_position()
-with open("home_pos.json", "w") as f:
-    json.dump(pos, f)
-minescript.echo(f"Saved to file home location: {pos}")

--- a/stop.py
+++ b/stop.py
@@ -1,5 +1,13 @@
+import json
+
+import init
 from system.lib import minescript
 
+with open(init.macro_info_file_path, "r") as f:
+    data = json.load(f)
+data['active'] = False
+with open(init.macro_info_file_path, "w") as f:
+    json.dump(data, f, indent = 4)
 minescript.execute("\suspend 1")
 minescript.player_press_attack(False)
 minescript.player_press_left(False)


### PR DESCRIPTION
## Changes
- Changed `set_home` to `init`. This is the script you should run everytime you start farming as it sets up intial farm location, orientation, and other info needed for the macro checker.
- The macro checker currently checks 4 things:
    - Camera orientation change
    - Staying in one place for too long
    - A TP that changes you're coordinates a lot
    - Staying within the "bounding box" of the farm
- The new `init` also contains the farm dimensions. The only one added currently is sf/mf/sc

## FLUPs
- A lot of these changes were based on the sf/mf/sc (and technically wr) farm. This should theoretically work for melon (if you just set the melon farm width to like 0 or something), but no testing was done. This will NOT work for potato, nw, etc. (just the farms that are not flat and have changes in y coordinate).
- Note: ran into a bug (i think it was the original macro itself ngl) that caused the "stayed in one place too long" check to trigger because it ran in the wrong direction and got stuck at the edge of a lane. Couldn't reproduce it so will assume everything is working well.